### PR TITLE
Add tests and update app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,9 +8,12 @@ from peewee import *
 from datetime import datetime
 from pymysql import Time
 from playhouse.shortcuts import model_to_dict
+import re
 
 load_dotenv()
 app = Flask(__name__)
+
+EMAIL_REGEX = "^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$"
 
 if os.getenv("TESTING") == "true":
     print("Running in test mode")
@@ -160,6 +163,14 @@ def post_time_line_post():
     name = request.values.get('name')
     email = request.values.get('email')
     content = request.values.get('content')
+    
+    if name == None or name == str():
+        return "Invalid name", 400
+    if content == None or content == str():
+        return "Invalid content", 400
+    if not re.match(EMAIL_REGEX, email):
+        return "Invalid email", 400
+    
     timeline_post = TimelinePost.create(name=name, email=email, content = content)
 
     return model_to_dict(timeline_post)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,11 +12,15 @@ from playhouse.shortcuts import model_to_dict
 load_dotenv()
 app = Flask(__name__)
 
-my_db = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
-        user=os.getenv("MYSQL_USER"),
-        password=os.getenv("MYSQL_PASSWORD"),
-        host=os.getenv("MYSQL_HOST"),
-        port=3306)
+if os.getenv("TESTING") == "true":
+    print("Running in test mode")
+    my_db = SqliteDatabase('file:memory?mode=memory&cache=shared', uri=True)
+else:
+    my_db = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
+            user=os.getenv("MYSQL_USER"),
+            password=os.getenv("MYSQL_PASSWORD"),
+            host=os.getenv("MYSQL_HOST"),
+            port=3306)
 
 print(my_db)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -157,9 +157,9 @@ def adventures_page():
 
 @app.route('/api/timeline_post', methods=['POST'])
 def post_time_line_post():
-    name = request.form['name']
-    email = request.form['email']
-    content = request.form['content']
+    name = request.values.get('name')
+    email = request.values.get('email')
+    content = request.values.get('content')
     timeline_post = TimelinePost.create(name=name, email=email, content = content)
 
     return model_to_dict(timeline_post)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,26 @@
+import unittest
+import os
+os.environ['TESTING'] = 'true'
+
+from app import app
+
+class AppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        
+    def test_home(self):
+        response = self.client.get('/')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert "<title>Javier Solis</title>" in html
+        # TODO: Add more tests relating to the home page
+
+    def test_timeline(self):
+        response = self.client.get('/api/timeline_post')
+        assert response.status_code == 200
+        assert response.is_json
+        json = response.get_json()
+        assert "timeline_posts" in json
+        assert len(json['timeline_posts']) == 0
+        # TODO: Add more tests relating to the /api/timeline_post GET and POST APIs
+        # TODO: Add more tests relating to the timeline page

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+from flask import json
+from playhouse.shortcuts import model_to_dict
 os.environ['TESTING'] = 'true'
 
 from app import app
@@ -13,14 +15,41 @@ class AppTestCase(unittest.TestCase):
         assert response.status_code == 200
         html = response.get_data(as_text=True)
         assert "<title>Javier Solis</title>" in html
-        # TODO: Add more tests relating to the home page
+        assert "<div id=\"user-picture\" class=\"user-picture\">" in html
+        assert "<div class=\"main-content\">" in html
 
     def test_timeline(self):
-        response = self.client.get('/api/timeline_post')
-        assert response.status_code == 200
-        assert response.is_json
-        json = response.get_json()
-        assert "timeline_posts" in json
-        assert len(json['timeline_posts']) == 0
-        # TODO: Add more tests relating to the /api/timeline_post GET and POST APIs
+        response_before = self.client.get('/api/timeline_post')
+        assert response_before.status_code == 200
+        assert response_before.is_json
+        json_before = response_before.get_json()
+        assert "timeline_posts" in json_before
+        assert len(json_before['timeline_posts']) == 0
+        # Create 2 posts
+        post_1 = self.client.post(
+            '/api/timeline_post',
+            data={
+                'name': 'John Doe',
+                'email': 'john@example.com',
+                'content': "Hello world, I'm John!"
+            },
+        )
+        assert post_1.get_json()['id'] == 1
+        post_2 = self.client.post(
+            '/api/timeline_post',
+            data={
+                'name': 'Jane Doe',
+                'email': 'jane@example.com',
+                'content': "Hello world, I'm Jane!"
+            },
+        )
+        assert post_2.get_json()['id'] == 2
+        # Get posts
+        response_after = self.client.get('/api/timeline_post')
+        assert response_after.status_code == 200
+        assert response_after.is_json
+        json_after = response_after.get_json()
+        assert "timeline_posts" in json_after
+        assert len(json_after['timeline_posts']) == 2
+        assert json_after['timeline_posts'][0]['name'] == 'Jane Doe'
         # TODO: Add more tests relating to the timeline page

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,3 +58,42 @@ class AppTestCase(unittest.TestCase):
         html_tl = response_tl.get_data(as_text=True)
         assert "<title>Javier Solis</title>" in html_tl
         assert "<div id=\"timeline\">" in html_tl
+
+    def test_malformed_timeline_post(self):
+        # POST request missing name
+        response = self.client.post(
+            '/api/timeline_post',
+            data={
+                'email': 'john@example.com',
+                'content': "Hello world, I'm John!"
+            },
+        )
+        assert response.status_code == 400
+        html = response.get_data(as_text=True)
+        assert "Invalid name" in html
+        
+        # POST request with empty content
+        response = self.client.post(
+            '/api/timeline_post',
+            data={
+                'name': 'John Doe',
+                'email': 'john@example.com',
+                'content': ""
+            },
+        )
+        assert response.status_code == 400
+        html = response.get_data(as_text=True)
+        assert "Invalid content" in html
+
+        # POST request with malformed email
+        response = self.client.post(
+            '/api/timeline_post',
+            data={
+                'name': 'John Doe',
+                'email': 'not-an-email',
+                'content': "Hello world, I'm John!"
+            },
+        )
+        assert response.status_code == 400
+        html = response.get_data(as_text=True)
+        assert "Invalid email" in html

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,4 +52,9 @@ class AppTestCase(unittest.TestCase):
         assert "timeline_posts" in json_after
         assert len(json_after['timeline_posts']) == 2
         assert json_after['timeline_posts'][0]['name'] == 'Jane Doe'
-        # TODO: Add more tests relating to the timeline page
+        # Retrieve Timeline page
+        response_tl = self.client.get('/timeline')
+        assert response_tl.status_code == 200
+        html_tl = response_tl.get_data(as_text=True)
+        assert "<title>Javier Solis</title>" in html_tl
+        assert "<div id=\"timeline\">" in html_tl

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,40 @@
+import unittest
+from peewee import *
+
+from app import TimelinePost
+
+MODELS = [TimelinePost]
+
+# In-memory SQLite database for tests
+test_db = SqliteDatabase(':memory:')
+
+class TestTimelinePost(unittest.TestCase):
+    def setUp(self):
+        # Bind model classes to database non-recursively because there is a
+        # complete list of all models
+        test_db.bind(MODELS, bind_refs=False, bind_backrefs=False)
+
+        test_db.connect()
+        test_db.create_tables(MODELS)
+
+    def tearDown(self):
+        # Not necessary for in-memory databases but a good practice
+        test_db.drop_tables(MODELS)
+
+        test_db.close()
+
+    def test_timeline_post(self):
+        # Create 2 posts
+        first_post = TimelinePost.create(
+            name='John Doe',
+            email='john@example.com',
+            content="Hello word, I'm John!"
+        )
+        assert first_post.id == 1
+        second_post = TimelinePost.create(
+            name='Jane Doe',
+            email='jane@example.com',
+            content="Hello word, I'm Jane!"
+        )
+        assert second_post.id == 2
+        # TODO: Get timeline posts and assert they are correct

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,6 @@
 import unittest
 from peewee import *
+from playhouse.shortcuts import model_to_dict
 
 from app import TimelinePost
 
@@ -37,4 +38,6 @@ class TestTimelinePost(unittest.TestCase):
             content="Hello word, I'm Jane!"
         )
         assert second_post.id == 2
-        # TODO: Get timeline posts and assert they are correct
+        posts = [model_to_dict(p) for p in TimelinePost.select().order_by(TimelinePost.id.asc())]
+        assert posts[0]['id'] == 1
+        assert posts[1]['id'] == 2


### PR DESCRIPTION
- Add database tests
- Update app to instantiate in-memory database when testing
- Test response at `/`
- Test response at `/timeline`
- Test GET and POST `/api/timeline_post` endpoints
- Update app to retrieve request data as `values` instead of `form`
- Handle malformed timeline post requests (no name or content, malformed email address)